### PR TITLE
fix: kein anagram crash

### DIFF
--- a/buchstabenschuetteln.py
+++ b/buchstabenschuetteln.py
@@ -6,6 +6,7 @@ def anagramm(wort_1, wort_2):
 
     if laenge_1 != laenge_2:
         print("Das Wortpaar " + wort_1 + " und " + wort_2 + " ist kein Anagramm.")
+        return              # return beendet unteranderem die function (wie break eine schleife). mit return kann man zusaetzlich werte aus der funktion in den ueberliegenden code transportieren, welcher die funktion benutzt, was du bereits mit "wahl = input("Ana...") gemacht hast. der wert, welcher hinter return steht wird von der funktion zurueckgegeben (dieser steht dann zur laufzeit dort, wo die funktion aufgerufen wurde, nach dem diese ausgefuehrt wurde). er kann dann einer variable zugewiesen werden, oder einfach nicht benutzt werden.
     else:
         c1 = Counter(wort_1)
         c2 = Counter(wort_2)


### PR DESCRIPTION
was ist passiert?:
`Geben Sie bitte zwei Wörter ein:
1. Wort: hallo
2. Wort: Welt
Was möchten Sie?
Anagram (a oder A) oder Palindrom (p oder P)a
Das Wortpaar hallo und Welt ist kein Anagramm.
Traceback (most recent call last):
  File "/home/debian/jakobsStuff/anagram-palindrom-main/buchstabenschuetteln.py", line 47, in <module>
    anagramm(wort_1, wort_2)
  File "/home/debian/jakobsStuff/anagram-palindrom-main/buchstabenschuetteln.py", line 13, in anagramm
    if c1 == c2:
       ^^
UnboundLocalError: cannot access local variable 'c1' where it is not associated with a value

`

ich habe in meinem code durch ein kommentar alles erklaert